### PR TITLE
Add livestream.metadata.updated webhook payload

### DIFF
--- a/payloads/v1/events.ts
+++ b/payloads/v1/events.ts
@@ -3,16 +3,16 @@ import type {Emote} from './emote';
 /**
  * @see {@link https://docs.kick.com/events/event-types}
  */
-export type EventNames =
-    'chat.message.sent' |
-    'channel.followed' |
-    'channel.subscription.renewal' |
-    'channel.subscription.gifts' |
-    'channel.subscription.new' |
-    'livestream.status.updated' |
-    'livestream.metadata.updated' |
-    'moderation.banned' |
-    'kicks.gifted';
+export type EventNames
+    = 'chat.message.sent'
+        | 'channel.followed'
+        | 'channel.subscription.renewal'
+        | 'channel.subscription.gifts'
+        | 'channel.subscription.new'
+        | 'livestream.status.updated'
+        | 'livestream.metadata.updated'
+        | 'moderation.banned'
+        | 'kicks.gifted';
 
 export interface EventSubscription {
     app_id: string;
@@ -141,6 +141,22 @@ export interface LivestreamStatusUpdatedEvent {
     title: string;
     started_at: string;
     ended_at?: string | null;
+}
+
+export interface LivestreamMetadataUpdatedEvent {
+    eventType: 'livestream.metadata.updated';
+    eventVersion: '1';
+    broadcaster: EventUser;
+    metadata: {
+        title: string;
+        language: string;
+        has_mature_content: boolean;
+        category: {
+            id: number;
+            name: string;
+            thumbnail: string;
+        };
+    };
 }
 
 export interface ModerationBannedEventMetadata {

--- a/payloads/v1/events.ts
+++ b/payloads/v1/events.ts
@@ -156,6 +156,8 @@ export interface LivestreamMetadataUpdatedEvent {
             name: string;
             thumbnail: string;
         };
+        // 'Category' (capitalized) is not included here as it's deprecated
+        // See https://github.com/KickEngineering/KickDevDocs/issues/238
     };
 }
 


### PR DESCRIPTION
This adds the `livestream.metadata.updated` webhook payload.

Documentation: <https://docs.kick.com/events/event-types#livestream-metadata-updated>

Note: There appears to be problem right now with the live Kick API as it's returning the field `Category` rather than `category`. I submitted https://github.com/KickEngineering/KickDevDocs/issues/238 to report that. I'm keeping this PR in draft (with a workaround) in hopes that Kick addresses this soon-ish.