### PR TITLE
Add Kicks gifted payload

### DIFF
--- a/payloads/v1/webhooks.ts
+++ b/payloads/v1/webhooks.ts
@@ -1,5 +1,11 @@
 import type {Emote} from './emote';
 
+/**
+ * Represents a user in the context of most of Kick's webhook events,
+ * specifically those that include the is_anonymous field.
+ *
+ * @see WebhookBaseUser
+ */
 export interface WebhookUser extends WebhookBaseUser {
     is_anonymous: boolean;
 }
@@ -27,10 +33,13 @@ export interface WebhookUserWithIdentity extends WebhookUser {
     identity: WebhookIdentity;
 }
 
-export interface KicksGiftedWebhookUser extends WebhookBaseUser {
-    // This type is used specifically for kicks.gifted events where Kick's API
-    // does not provide the is_anonymous field that other webhook events have
-}
+/**
+ * Represents a user in the context of a "kicks gifted" webhook event. Kick's
+ * API does not provide the is_anonymous field that other webhook events have.
+ *
+ * @see WebhookBaseUser
+ */
+export interface KicksGiftedWebhookUser extends WebhookBaseUser {}
 
 export interface WebhookRepliesTo {
     message_id: string;

--- a/payloads/v1/webhooks.ts
+++ b/payloads/v1/webhooks.ts
@@ -1,18 +1,21 @@
 import type {Emote} from './emote';
 
-export interface WebhookUser {
+export interface WebhookUser extends WebhookBaseUser {
     is_anonymous: boolean;
-    user_id?: number;
-    username?: string;
-    is_verified?: boolean;
-    profile_picture?: string;
-    channel_slug?: string;
 }
 
 export interface WebhookBadge {
     text: string;
     type: string;
     count?: number;
+}
+
+export interface WebhookBaseUser {
+    user_id?: number;
+    username?: string;
+    is_verified?: boolean;
+    profile_picture?: string;
+    channel_slug?: string;
 }
 
 export interface WebhookIdentity {
@@ -22,6 +25,11 @@ export interface WebhookIdentity {
 
 export interface WebhookUserWithIdentity extends WebhookUser {
     identity: WebhookIdentity;
+}
+
+export interface KicksGiftedWebhookUser extends WebhookBaseUser {
+    // This type is used specifically for kicks.gifted events where Kick's API
+    // does not provide the is_anonymous field that other webhook events have
 }
 
 export interface WebhookRepliesTo {
@@ -102,4 +110,19 @@ export interface ModerationBannedEvent {
     moderator: WebhookUser;
     banned_user: WebhookUser;
     metadata: ModerationBannedEventMetadata;
+}
+
+export interface KicksGiftedEvent {
+    eventType: 'kicks.gifted';
+    eventVersion: '1';
+    broadcaster: KicksGiftedWebhookUser;
+    sender: KicksGiftedWebhookUser;
+    gift: {
+        amount: number;
+        name: string;
+        type: string;
+        tier: string;
+        message: string;
+    };
+    created_at: string;
 }


### PR DESCRIPTION
Adds the webhook payload for Kicks Gifted (<https://docs.kick.com/events/event-types#kicks-gifted>).

Note: Consistency is not always a strong point in the Kick API, and in this particular case, the broadcaster and sender do not have an `is_anonymous` field like all of the other events. The `is_anonymous` is currently a required field of `WebhookUser`. I reorganized things to account for this (base interface `WebhookBaseUser`, extended by `WebhookUser` for all the existing stuff and `KicksGiftedWebhookUser` for this webhook). I was wary about just changing `is_anonymous` to `is_anonymous?` because of backward compatibility implications. Be sure to double check to make sure you like this approach...