### PR TITLE
Add channel reward payloads and REST

### DIFF
--- a/payloads/v1/events.ts
+++ b/payloads/v1/events.ts
@@ -1,18 +1,20 @@
 import type {Emote} from './emote';
+import type {EventChannelReward} from './rewards';
 
 /**
  * @see {@link https://docs.kick.com/events/event-types}
  */
-export type EventNames =
-    'chat.message.sent' |
-    'channel.followed' |
-    'channel.subscription.renewal' |
-    'channel.subscription.gifts' |
-    'channel.subscription.new' |
-    'livestream.status.updated' |
-    'livestream.metadata.updated' |
-    'moderation.banned' |
-    'kicks.gifted';
+export type EventNames
+    = 'chat.message.sent'
+        | 'channel.followed'
+        | 'channel.subscription.renewal'
+        | 'channel.subscription.gifts'
+        | 'channel.subscription.new'
+        | 'channel.reward.redemption.updated'
+        | 'livestream.status.updated'
+        | 'livestream.metadata.updated'
+        | 'moderation.banned'
+        | 'kicks.gifted';
 
 export interface EventSubscription {
     app_id: string;
@@ -131,6 +133,18 @@ export interface NewSubscriptionEvent {
     duration: number;
     created_at: string;
     expires_at: string;
+}
+
+export interface ChannelRewardRedemptionEvent {
+    eventType: 'channel.reward.redemption.updated';
+    eventVersion: '1';
+    id: string;
+    user_input: string;
+    status: 'pending' | 'accepted' | 'rejected';
+    redeemed_at: string;
+    reward: EventChannelReward;
+    redeemer: EventBaseUser;
+    broadcaster: EventBaseUser;
 }
 
 export interface LivestreamStatusUpdatedEvent {

--- a/payloads/v1/index.ts
+++ b/payloads/v1/index.ts
@@ -4,4 +4,5 @@ export * from './emote';
 export * from './events';
 export * from './livestream';
 export * from './oauth2';
+export * from './rewards';
 export * from './users';

--- a/payloads/v1/rewards.ts
+++ b/payloads/v1/rewards.ts
@@ -1,0 +1,26 @@
+/**
+ * Reward information in webhook events
+ * NOTE: This is a simplified version of ChannelReward without some fields
+ * that are not provided in event payloads.
+ */
+export interface EventChannelReward {
+    /**
+     * Unique identifier for the reward (ULID format)
+     */
+    id: string;
+
+    /**
+     * Display name of the reward
+     */
+    title: string;
+
+    /**
+     * Cost of the reward in channel points
+     */
+    cost: number;
+
+    /**
+     * Description of the reward
+     */
+    description: string;
+}

--- a/rest/v1/index.ts
+++ b/rest/v1/index.ts
@@ -7,6 +7,7 @@ export * from './livestreams';
 export * from './moderation';
 export * from './oauth2';
 export * from './public-key';
+export * from './rewards';
 export * from './users';
 
 export const APIVersion = 'v1';
@@ -106,5 +107,23 @@ export const Routes = {
      */
     EventsSubscriptions() {
         return `/events/subscriptions` as const;
+    },
+
+    /**
+     * Route for:
+     * - GET `/channels/rewards`
+     * - POST `/channels/rewards`
+     */
+    ChannelsRewards() {
+        return `/channels/rewards` as const;
+    },
+
+    /**
+     * Route for:
+     * - PATCH `/channels/rewards/{id}`
+     * - DELETE `/channels/rewards/{id}`
+     */
+    ChannelsReward(id: string) {
+        return `/channels/rewards/${id}` as const;
     },
 };

--- a/rest/v1/rewards.ts
+++ b/rest/v1/rewards.ts
@@ -1,0 +1,166 @@
+import type {RESTResult} from './global';
+
+/**
+ * A Kick channel reward
+ *
+ * @see {@link https://docs.kick.com/apis/channel-rewards}
+ */
+export interface ChannelReward {
+    /**
+     * Unique identifier for the reward (ULID format)
+     */
+    id: string;
+
+    /**
+     * Display name of the reward (max 50 characters)
+     */
+    title: string;
+
+    /**
+     * Description of the reward (max 200 characters)
+     */
+    description: string;
+
+    /**
+     * Cost of the reward in channel points
+     */
+    cost: number;
+
+    /**
+     * Hex color code for the reward background
+     */
+    background_color: string;
+
+    /**
+     * Whether this reward is enabled
+     */
+    is_enabled: boolean;
+
+    /**
+     * Whether this reward requires user input
+     */
+    is_user_input_required: boolean;
+
+    /**
+     * Whether redemptions of this reward should skip the request queue
+     */
+    should_redemptions_skip_request_queue: boolean;
+}
+
+/**
+ * Request body for creating a channel reward
+ *
+ * @see {@link https://docs.kick.com/apis/channel-rewards#post-channels-rewards}
+ */
+export interface ChannelRewardCreateRequest {
+    /**
+     * Display name of the reward (required, max 50 characters)
+     */
+    title: string;
+
+    /**
+     * Cost of the reward in channel points (required, min 1)
+     */
+    cost: number;
+
+    /**
+     * Description of the reward (optional, max 200 characters)
+     */
+    description?: string;
+
+    /**
+     * Hex color code for the reward background (optional, default #00e701)
+     */
+    background_color?: string;
+
+    /**
+     * Whether this reward is enabled (optional, default true)
+     */
+    is_enabled?: boolean;
+
+    /**
+     * Whether this reward requires user input (optional, default false)
+     */
+    is_user_input_required?: boolean;
+
+    /**
+     * Whether redemptions of this reward should skip the request queue (optional, default false)
+     */
+    should_redemptions_skip_request_queue?: boolean;
+}
+
+/**
+ * Request body for updating a channel reward
+ *
+ * All fields are optional
+ *
+ * @see {@link https://docs.kick.com/apis/channel-rewards#patch-channels-rewards-id}
+ */
+export interface ChannelRewardUpdateRequest {
+    /**
+     * Display name of the reward (max 50 characters)
+     */
+    title?: string;
+
+    /**
+     * Cost of the reward in channel points (min 1)
+     */
+    cost?: number;
+
+    /**
+     * Description of the reward (max 200 characters)
+     */
+    description?: string;
+
+    /**
+     * Hex color code for the reward background
+     */
+    background_color?: string;
+
+    /**
+     * Whether this reward is enabled
+     */
+    is_enabled?: boolean;
+
+    /**
+     * Whether this reward requires user input
+     */
+    is_user_input_required?: boolean;
+
+    /**
+     * Whether redemptions of this reward should skip the request queue
+     */
+    should_redemptions_skip_request_queue?: boolean;
+}
+
+/**
+ * Response from getting channel rewards
+ *
+ * @see {@link https://docs.kick.com/apis/channel-rewards#get-channels-rewards}
+ */
+export type RESTGetChannelRewardsResult = RESTResult<ChannelReward[]>;
+
+/**
+ * Response from creating a channel reward
+ *
+ * @see {@link https://docs.kick.com/apis/channel-rewards#post-channels-rewards}
+ */
+export type RESTCreateChannelRewardResult = RESTResult<ChannelReward>;
+
+/**
+ * Response from updating a channel reward
+ *
+ * Returns 204 No Content on success
+ *
+ * @see {@link https://docs.kick.com/apis/channel-rewards#patch-channels-rewards-id}
+ */
+export type RESTUpdateChannelRewardResult = never;
+
+/**
+ * Response from deleting a channel reward
+ *
+ * Returns 204 No Content on success
+ *
+ * @see {@link https://docs.kick.com/apis/channel-rewards#delete-channels-rewards-id}
+ */
+export type RESTDeleteChannelRewardResult = never;


### PR DESCRIPTION
Adds:
- <https://docs.kick.com/events/event-types#channel-reward-redemption-updated>
- <https://docs.kick.com/apis/channel-rewards>

These were added a couple days ago.

I've been using this code in my Firebot - Kick integration and both the REST API calls and the payloads seem to work.

I just used `EventBaseUser` to make `is_anonymous` match the payloads, and didn't create a separate type for the user account. I had asked the Kick devs in https://github.com/KickEngineering/KickDevDocs/issues/305 to be consistent with `is_anonymous` and they just closed the issue. If you want this to have its own type or whatever, let me know.